### PR TITLE
#10555

### DIFF
--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -1458,7 +1458,7 @@ BOOL _fileIsSymbolicLink(const unz_file_info *fileInfo);
         //   is expected to not include a byte order mark (BOM).
         
         //  Code Page 437 corresponds to kCFStringEncodingDOSLatinUS
-        NSStringEncoding encoding = CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingDOSLatinUS);
+        NSStringEncoding encoding = CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingDOSRussian);
         NSString* strPath = [NSString stringWithCString:filename encoding:encoding];
         if (strPath) {
             return strPath;


### PR DESCRIPTION
Многие файлы/папки с названием на русском языке, находящиеся в zip - архиве, имеют сбитые кодировки в названии при просмотре файлов и папок в архиве